### PR TITLE
Add cfn-nag to auditing

### DIFF
--- a/arsenal.md
+++ b/arsenal.md
@@ -26,6 +26,8 @@ Scout2: https://github.com/nccgroup/Scout2
 
 Prowler: https://github.com/toniblyx/prowler
 
+cfn-nag: https://github.com/stelligent/cfn_nag
+
 Policy changes & Insecure config: https://github.com/Netflix/security_monkey
 
 Policy & Encryption; https://github.com/capitalone/cloud-custodian


### PR DESCRIPTION
A CF script linting library.
Looks for:
-  IAM rules that are too permissive (wildcards)
-  Security group rules that are too permissive (wildcards)
-  Access logs that aren't enabled
-  Encryption that isn't enabled
